### PR TITLE
Implement Profile Component and Integrate into Dashboard Navigation

### DIFF
--- a/StarshipWebApp/Components/Pages/HomeDashboard/DashboardNavigationTabs.razor
+++ b/StarshipWebApp/Components/Pages/HomeDashboard/DashboardNavigationTabs.razor
@@ -4,48 +4,46 @@
 
 
 <MudTabs Elevation="4" Rounded="true" Centered="true" Color="@Color.Primary" style="max-width:2200">
-        <MudTabPanel Text="Main Menu">
+    <MudTabPanel Text="Main Menu">
 
-            <Animate Animation="Animations.SlideUp">
-                <RadzenRow JustifyContent="JustifyContent.Center" Style="margin-top:12px;">
-
-                    <RadzenColumn SizeXS="12" SizeSM="6" SizeMD="4" SizeLG="3" SizeXL="2">
-                        <DashboardButton url_link="/Starships" buttonText="Starships" imagePath="./images/ships.png"></DashboardButton>
-                    </RadzenColumn>
-
-                    <RadzenColumn SizeXS="12" SizeSM="6" SizeMD="4" SizeLG="3" SizeXL="2">
-                        <DashboardButton url_link="/Pilots" buttonText="Pilots" isInDevelopment="true" imagePath="./images/pilots.png"></DashboardButton>
-                    </RadzenColumn>
-
-                    <RadzenColumn SizeXS="12" SizeSM="6" SizeMD="4" SizeLG="3" SizeXL="2">
-                        <DashboardButton url_link="/Films" buttonText="Films" isInDevelopment="true" imagePath="./images/films.png"></DashboardButton>
-                    </RadzenColumn>
-
-                </RadzenRow>
-            </Animate>
-        </MudTabPanel>
-        <MudTabPanel Text="Settings">
-            <Animate Animation="Animations.FadeUp">
+        <Animate Animation="Animations.SlideUp">
             <RadzenRow JustifyContent="JustifyContent.Center" Style="margin-top:12px;">
 
-                    <RadzenColumn Size="4" SizeMD="4" SizeLG="3">
-                        <DashboardButton url_link="/Profile" buttonText="View Profile" ImagePath="" />
+                <RadzenColumn SizeXS="12" SizeSM="6" SizeMD="4" SizeLG="3" SizeXL="2">
+                    <DashboardButton url_link="/Starships" buttonText="Starships" imagePath="./images/ships.png"></DashboardButton>
+                </RadzenColumn>
+
+                <RadzenColumn SizeXS="12" SizeSM="6" SizeMD="4" SizeLG="3" SizeXL="2">
+                    <DashboardButton url_link="/Pilots" buttonText="Pilots" isInDevelopment="true" imagePath="./images/pilots.png"></DashboardButton>
+                </RadzenColumn>
+
+                <RadzenColumn SizeXS="12" SizeSM="6" SizeMD="4" SizeLG="3" SizeXL="2">
+                    <DashboardButton url_link="/Films" buttonText="Films" isInDevelopment="true" imagePath="./images/films.png"></DashboardButton>
+                </RadzenColumn>
+
+            </RadzenRow>
+        </Animate>
+    </MudTabPanel>
+    <MudTabPanel Text="Profile">
+
+        <RadzenRow JustifyContent="JustifyContent.Center" Style="margin-top:12px;">
+
+            <Profile></Profile>
+
+        </RadzenRow>
+
+    </MudTabPanel>
+    <AuthorizeView Roles="Admin, Developer">
+        <MudTabPanel Text="Admin Services">
+            <Animate Animation="Animations.FadeUp">
+                <RadzenRow JustifyContent="JustifyContent.Center">
+
+                    <RadzenColumn Size="4" SizeMD="4" SizeLG="2" Style="margin-top:12px;">
+                        <DashboardButton url_link="/Users" buttonText="Manage Accounts" imagePath="users" />
                     </RadzenColumn>
 
                 </RadzenRow>
             </Animate>
         </MudTabPanel>
-        <AuthorizeView Roles="Admin, Developer">
-            <MudTabPanel Text="Admin Services">
-                <Animate Animation="Animations.FadeUp">
-                    <RadzenRow JustifyContent="JustifyContent.Center">
-
-                    <RadzenColumn Size="4" SizeMD="4" SizeLG="2" Style="margin-top:12px;">
-                            <DashboardButton url_link="/Users" buttonText="Manage Accounts" imagePath="users" />
-                        </RadzenColumn>
-
-                    </RadzenRow>
-                </Animate>
-            </MudTabPanel>
-        </AuthorizeView>
-    </MudTabs>
+    </AuthorizeView>
+</MudTabs>

--- a/StarshipWebApp/Components/Pages/Profile.razor
+++ b/StarshipWebApp/Components/Pages/Profile.razor
@@ -1,0 +1,42 @@
+﻿@attribute [Authorize]
+@page "/Profile"
+@using Radzen
+@using Radzen.Blazor
+
+<RadzenStack Orientation="Orientation.Horizontal">
+    <Animate Animation="Animations.FlipRight">
+        <img src="./images/mandalorian-skull.png" Style="width: 360px; height: 360px;" />
+    </Animate>
+
+    <Animate Animation="Animations.FlipUp">
+        
+        <RadzenStack Orientation="Orientation.Vertical">
+            <RadzenLabel>
+                Name: <strong>@User.GivenName</strong>
+            </RadzenLabel>
+            <RadzenLabel>
+                Email: <strong>@User.Email</strong>
+            </RadzenLabel>
+            <RadzenLabel>
+                Clan: <strong>@User.FamilyName</strong>
+            </RadzenLabel>
+            <RadzenLabel>
+                Wanted: <strong>@(new Random().Next(1, 3) % 2 == 0 ? "Yes" : "NO")</strong>
+            </RadzenLabel>
+            <RadzenLabel>
+                Planets Visited: <strong>@(new Random().Next(1, 1000).ToString())</strong>
+            </RadzenLabel>
+            <RadzenLabel>
+                Cool: <strong>@(new Random().Next(1, 3) % 2 == 0 ? "Yes" : "NO")</strong>
+            </RadzenLabel>
+        </RadzenStack>
+    </Animate>
+
+</RadzenStack>
+
+
+@code {
+    [CascadingParameter(Name = "User")]
+    public User User { get; set; } = new();
+
+}


### PR DESCRIPTION
PR Description:
This PR introduces a new Profile component and integrates it into the main dashboard navigation under its own tab.

Changes in this PR:

- Implemented `Profile.razor` component displaying user info using animated Radzen UI elements
  - Shows name, email, clan, wanted status, planets visited, and coolness factor
  - Uses playful randomly generated stats for demo purposes

- Added a new "Profile" tab to `DashboardNavigationTabs.razor`
  - Includes animation and responsive layout consistent with other dashboard sections
  - Accessible only to authenticated users via `[Authorize]` directive

- Minor cleanup and reorganization of tab layout and indentation for consistency