### PR TITLE
Ignore auto-generated ARM deployment profile file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -489,3 +489,5 @@ $RECYCLE.BIN/
 # App settings
 appsettings.*.json
 !appsettings.Development.json   # optionally track dev settings
+
+StarshipWebApp/Properties/ServiceDependencies/DevMandoStarships/profile.arm.json


### PR DESCRIPTION
Description:
- Updated `.gitignore` to exclude `profile.arm.json`, which was unintentionally tracked in a previous commit
- This file is generated by Visual Studio for Azure deployment and is specific to the local environment
- Keeping it out of source control avoids unnecessary noise and potential config conflicts between developers
